### PR TITLE
Adding store button

### DIFF
--- a/src/utils/builders/DialogBuilder.ts
+++ b/src/utils/builders/DialogBuilder.ts
@@ -83,6 +83,24 @@ export class DialogBuilder {
   }
 
   /**
+   * Adds a button
+   * @param {string} name The name of the button
+   * @param {string} title The text in the button
+   * @param {string} image The rttex image of the button
+   * @param {string} description The description of item being purchased
+   * @param {object} imagepos The position of the image
+   * @param {string | number} cost The cost of the item
+   * @returns {DialogBuilder}
+   */
+
+  public addStoreButton(name: string, title: string, description: string, image: string = "", imagepos: { x: number, y: number } = { x: 0, y: 0} , cost: string | number = ""): DialogBuilder {
+        
+    this.#str += `add_button|${name}|${title}|${image}|${description}|${imagepos.x}|${imagepos.y}|${cost}|\n`;
+    
+    return this;
+}
+
+  /**
    * Adds a button with icon.
    * @param {string | number} name The name of the button
    * @param {string | number} itemID The button icon using itemID


### PR DESCRIPTION
Adding a store button that can display an rttex image with coordinates provided as well as the cost in gems down below
When clicked this button brings up a menu with item title and description, as well the button with price which when clicked fires a "buy" action with `item` value as the name of the button
![Screenshot 2024-08-14 223707](https://github.com/user-attachments/assets/f29b2ce6-c686-4f14-b12d-bfe9bdfd30e9)
![Screenshot 2024-08-14 235851](https://github.com/user-attachments/assets/c8164001-5e25-4979-96ac-6a9addda990f)
